### PR TITLE
Implement a model to determine when it's better to use a linear merge sum rather than the standard quadratic merge sum

### DIFF
--- a/src/ae_adaptive_predicate_eval.hpp
+++ b/src/ae_adaptive_predicate_eval.hpp
@@ -53,10 +53,13 @@ template <typename E_, typename eval_type, typename allocator_type_>
 class adaptive_eval_impl {
 public:
   using E = std::remove_cvref_t<E_>;
+  using allocator_type = std::remove_cvref_t<allocator_type_>;
 
-  explicit adaptive_eval_impl(allocator_type_ mem_pool)
-      : exact_storage{num_partials_for_exact<E>(),
-                      std::forward<allocator_type_>(mem_pool)} {}
+  adaptive_eval_impl() = default;
+
+  explicit adaptive_eval_impl(allocator_type mem_pool_)
+      : cache(), mem_pool(std::forward<allocator_type_>(mem_pool_)),
+        exact_storage{num_partials_for_exact<E>(), mem_pool} {}
 
   explicit adaptive_eval_impl(const E_ &) : adaptive_eval_impl() {}
 
@@ -78,24 +81,13 @@ private:
         exact_storage.data() + begin_idx, num_partials_for_exact<subexpr_t>()};
   }
 
-  // exact_eval_root computes the requested result of the (sub)expression to 1/2
-  // epsilon precision
+  // exact_eval_round computes the requested result of the (sub)expression to
+  // 1/2 epsilon precision
   template <std::size_t branch_id>
-  std::pair<eval_type, eval_type> exact_eval_root(evaluatable auto &&expr) {
+  std::pair<eval_type, eval_type> exact_eval_round(evaluatable auto &&expr) {
     using sub_expr = decltype(expr);
     auto memory = get_memory<branch_id, sub_expr>();
-    if constexpr (_impl::linear_merge_lower_latency<eval_type, sub_expr>()) {
-      exact_eval_root<_impl::left_branch_id(branch_id)>(expr.lhs());
-      exact_eval_root<_impl::right_branch_id<
-          typename std::remove_cvref<sub_expr>::type>(branch_id)>(expr.rhs());
-      const auto midpoint =
-          memory.begin() + num_partials_for_exact<decltype(expr.lhs())>();
-      _impl::merge_sum_linear_fast(memory, midpoint);
-    } else {
-      exact_eval<branch_id>(std::forward<sub_expr>(expr), memory);
-      _impl::merge_sum(memory);
-    }
-
+    exact_eval_merge<branch_id>(std::forward<sub_expr>(expr), memory);
     const eval_type exact_result = std::reduce(memory.begin(), memory.end());
     cache[branch_id] = exact_result;
     return {exact_result, abs(exact_result) *
@@ -141,7 +133,7 @@ private:
           // guarantees we deal with the largest part of the error, making
           // the fall-through case very unlikely
           const auto [new_left, new_left_err] =
-              exact_eval_root<_impl::left_branch_id(branch_id)>(expr.lhs());
+              exact_eval_round<_impl::left_branch_id(branch_id)>(expr.lhs());
 
           const auto [new_result, new_abs_err] =
               _impl::eval_with_max_abs_err<Op>(new_left, new_left_err,
@@ -153,7 +145,7 @@ private:
           }
         } else {
           const auto [new_right, new_right_err] =
-              exact_eval_root<_impl::right_branch_id<sub_expr>(branch_id)>(
+              exact_eval_round<_impl::right_branch_id<sub_expr>(branch_id)>(
                   expr.rhs());
           const auto [new_result, new_abs_err] =
               _impl::eval_with_max_abs_err<Op>(left_result, left_abs_err,
@@ -166,7 +158,7 @@ private:
         }
       }
     }
-    return exact_eval_root<branch_id>(std::forward<sub_expr_>(expr));
+    return exact_eval_round<branch_id>(std::forward<sub_expr_>(expr));
   }
 
   // Returns the result and maximum absolute error from computing the expression
@@ -227,6 +219,23 @@ private:
     }
   }
 
+  template <std::size_t branch_id, typename sub_expr>
+    requires expr_type<sub_expr> || arith_number<sub_expr>
+  constexpr void
+  exact_eval_merge(sub_expr &&e,
+                   std::span<eval_type, num_partials_for_exact<sub_expr>()>
+                       partial_results) noexcept {
+    exact_eval<branch_id>(std::forward<sub_expr>(e), partial_results);
+    if constexpr (!_impl::linear_merge_lower_latency<eval_type, sub_expr>()) {
+      // In cases where the linear merge algorithm doesn't make sense, we need
+      // to ensure we can compute the correctly rounded result with just a
+      // reduction.
+      // In cases where the linear merge algorithm does make sense, this is
+      // already handled by exact_eval
+      _impl::merge_sum(partial_results);
+    }
+  }
+
   template <std::size_t branch_id, typename sub_expr_>
     requires expr_type<sub_expr_> || arith_number<sub_expr_>
   constexpr void
@@ -249,6 +258,20 @@ private:
           partial_results.template subspan<reserve_left, reserve_right>();
       exact_eval<_impl::right_branch_id<sub_expr>(branch_id)>(e.rhs(),
                                                               storage_right);
+      if constexpr (_impl::linear_merge_lower_latency<eval_type, sub_expr_>()) {
+        // Since we're at a point where we want to use linear merge sum,
+        // we need to ensure the lower levels of the tree have been merged
+        // together. If they're also at a point where linear merge sum is being
+        // used, then they're already merged and we don't need to do anything
+        if constexpr (!_impl::linear_merge_lower_latency<eval_type,
+                                                         decltype(e.lhs())>()) {
+          _impl::merge_sum(storage_left);
+        }
+        if constexpr (!_impl::linear_merge_lower_latency<eval_type,
+                                                         decltype(e.rhs())>()) {
+          _impl::merge_sum(storage_right);
+        }
+      }
 
       using Op = typename sub_expr::Op;
       if constexpr (std::is_same_v<std::plus<>, Op> ||
@@ -258,11 +281,22 @@ private:
             v = -v;
           }
         }
+        if constexpr (_impl::linear_merge_lower_latency<eval_type,
+                                                        sub_expr_>()) {
+          _impl::merge_sum_linear(partial_results,
+                                  partial_results.begin() + reserve_left);
+        }
       } else if constexpr (std::is_same_v<std::multiplies<>, Op>) {
         const auto storage_mult =
             partial_results.template last<partial_results.size() -
                                           reserve_left - reserve_right>();
-        _impl::sparse_mult(storage_left, storage_right, storage_mult);
+        if constexpr (_impl::linear_merge_lower_latency<eval_type,
+                                                        sub_expr_>()) {
+          _impl::sparse_mult_merge(storage_left, storage_right, partial_results,
+                                   mem_pool);
+        } else {
+          _impl::sparse_mult(storage_left, storage_right, storage_mult);
+        }
       }
     } else if constexpr (!std::is_same_v<additive_id, sub_expr>) {
       // additive_id is zero, so we don't actually have memory allocated for it
@@ -272,7 +306,9 @@ private:
 
   std::array<std::optional<eval_type>, num_internal_nodes<E>()> cache;
 
-  std::vector<eval_type, std::remove_cvref_t<allocator_type_>> exact_storage;
+  allocator_type mem_pool;
+
+  std::vector<eval_type, allocator_type> exact_storage;
 };
 
 } // namespace _impl

--- a/src/ae_adaptive_predicate_eval.hpp
+++ b/src/ae_adaptive_predicate_eval.hpp
@@ -87,9 +87,11 @@ private:
   std::pair<eval_type, eval_type> exact_eval_round(evaluatable auto &&expr) {
     using sub_expr = decltype(expr);
     auto memory = get_memory<branch_id, sub_expr>();
-    exact_eval_merge<branch_id>(std::forward<sub_expr>(expr), memory);
-    const eval_type exact_result = std::reduce(memory.begin(), memory.end());
-    cache[branch_id] = exact_result;
+    auto result_end =
+        exact_eval_merge<branch_id>(std::forward<sub_expr>(expr), memory);
+    const eval_type exact_result = std::reduce(memory.begin(), result_end);
+    cache[branch_id] =
+        std::pair{exact_result, std::distance(memory.begin(), result_end)};
     return {exact_result, abs(exact_result) *
                               std::numeric_limits<eval_type>::epsilon() / 2.0};
   }
@@ -168,8 +170,8 @@ private:
     if constexpr (is_expr_v<sub_expr>) {
       const auto exact_eval_info = cache[branch_id];
       if (exact_eval_info) {
-        return {*exact_eval_info,
-                abs(*exact_eval_info) *
+        return {exact_eval_info->first,
+                abs(exact_eval_info->first) *
                     std::numeric_limits<eval_type>::epsilon() / 2.0};
       }
       using Op = typename sub_expr::Op;
@@ -221,35 +223,41 @@ private:
 
   template <std::size_t branch_id, typename sub_expr>
     requires expr_type<sub_expr> || arith_number<sub_expr>
-  constexpr void
+  constexpr auto
   exact_eval_merge(sub_expr &&e,
                    std::span<eval_type, num_partials_for_exact<sub_expr>()>
-                       partial_results) noexcept {
-    exact_eval<branch_id>(std::forward<sub_expr>(e), partial_results);
+                       partial_results) noexcept
+      -> decltype(partial_results.end()) {
+    auto partial_last =
+        exact_eval<branch_id>(std::forward<sub_expr>(e), partial_results);
     if constexpr (!_impl::linear_merge_lower_latency<eval_type, sub_expr>()) {
       // In cases where the linear merge algorithm doesn't make sense, we need
       // to ensure we can compute the correctly rounded result with just a
       // reduction.
       // In cases where the linear merge algorithm does make sense, this is
       // already handled by exact_eval
-      _impl::merge_sum(partial_results);
+      std::span nonzero_results{partial_results.begin(), partial_last};
+      auto nonzero_last = _impl::merge_sum(nonzero_results).second;
+      partial_last = partial_results.begin() +
+                     std::distance(nonzero_results.begin(), nonzero_last);
     }
+    return partial_last;
   }
 
   template <std::size_t branch_id, typename sub_expr_>
     requires expr_type<sub_expr_> || arith_number<sub_expr_>
-  constexpr void
+  constexpr auto
   exact_eval(sub_expr_ &&e,
              std::span<eval_type, num_partials_for_exact<sub_expr_>()>
-                 partial_results) noexcept {
+                 partial_results) noexcept -> decltype(partial_results.end()) {
     using sub_expr = std::remove_cvref_t<sub_expr_>;
     if constexpr (num_partials_for_exact<sub_expr>() == 0) {
-      return;
+      return partial_results.begin();
     } else if constexpr (is_expr_v<sub_expr>) {
       if (cache[branch_id]) {
-        return;
+        return partial_results.begin() + cache[branch_id]->second;
       }
-      partial_results[num_partials_for_exact<sub_expr>() - 1] = eval_type{0};
+      constexpr std::size_t left_id = _impl::left_branch_id(branch_id);
       constexpr std::size_t reserve_left =
           num_partials_for_exact<typename sub_expr::LHS>();
       constexpr std::size_t reserve_right =
@@ -259,13 +267,14 @@ private:
       const auto storage_left =
           partial_results.template subspan<start_left, reserve_left>();
 
-      exact_eval<_impl::left_branch_id(branch_id)>(e.lhs(), storage_left);
+      auto left_end = exact_eval<left_id>(e.lhs(), storage_left);
 
+      constexpr std::size_t start_right =
+          num_partials_for_exact<sub_expr>() - reserve_right;
       const auto storage_right =
-          partial_results
-              .template subspan<start_left + reserve_left, reserve_right>();
-      exact_eval<_impl::right_branch_id<sub_expr>(branch_id)>(e.rhs(),
-                                                              storage_right);
+          partial_results.template subspan<start_right, reserve_right>();
+      auto right_end = exact_eval<_impl::right_branch_id<sub_expr>(branch_id)>(
+          e.rhs(), storage_right);
 
       if constexpr (_impl::linear_merge_lower_latency<eval_type, sub_expr_>()) {
         // Since we're at a point where we want to use linear merge sum,
@@ -274,11 +283,17 @@ private:
         // used, then they're already merged and we don't need to do anything
         if constexpr (!_impl::linear_merge_lower_latency<eval_type,
                                                          decltype(e.lhs())>()) {
-          _impl::merge_sum(storage_left);
+          const std::span nonzero_left{storage_left.begin(), left_end};
+          left_end = storage_left.begin() +
+                     std::distance(nonzero_left.begin(),
+                                   _impl::merge_sum(nonzero_left).second);
         }
         if constexpr (!_impl::linear_merge_lower_latency<eval_type,
                                                          decltype(e.rhs())>()) {
-          _impl::merge_sum(storage_right);
+          const std::span nonzero_right{storage_right.begin(), right_end};
+          right_end = storage_right.begin() +
+                      std::distance(nonzero_right.begin(),
+                                    _impl::merge_sum(nonzero_right).second);
         }
       }
 
@@ -286,30 +301,52 @@ private:
       if constexpr (std::is_same_v<std::plus<>, Op> ||
                     std::is_same_v<std::minus<>, Op>) {
         if constexpr (std::is_same_v<std::minus<>, Op>) {
-          for (eval_type &v : storage_right) {
+          for (eval_type &v : std::span{storage_right.begin(), right_end}) {
             v = -v;
           }
         }
         if constexpr (_impl::linear_merge_lower_latency<eval_type,
                                                         sub_expr_>()) {
-          _impl::merge_sum_linear(partial_results,
-                                  partial_results.begin() + reserve_left);
+          std::span left_span{storage_left.begin(), left_end};
+          std::vector<eval_type, allocator_type> left_copy(mem_pool);
+          left_copy.reserve(left_span.size());
+          for (const auto v : left_span) {
+            left_copy.push_back(v);
+          }
+          return _impl::merge_sum_linear(
+                     partial_results, std::span{left_copy},
+                     std::span{storage_right.begin(), right_end})
+              .second;
+        } else {
+          // We must compact so that the returned end iterator doesn't include
+          // garbage data
+          return std::copy(storage_right.begin(), right_end,
+                           partial_results.begin() +
+                               std::distance(storage_left.begin(), left_end));
         }
       } else if constexpr (std::is_same_v<std::multiplies<>, Op>) {
         if constexpr (_impl::linear_merge_lower_latency<eval_type,
                                                         sub_expr_>()) {
-          _impl::sparse_mult_merge(storage_left, storage_right, partial_results,
-                                   mem_pool);
+          return _impl::sparse_mult_merge(
+              std::span{storage_left.begin(), left_end},
+              std::span{storage_right.begin(), right_end}, partial_results,
+              mem_pool);
         } else {
-          _impl::sparse_mult(storage_left, storage_right, partial_results);
+          return _impl::sparse_mult(storage_left, storage_right,
+                                    partial_results);
         }
       }
     } else {
       *partial_results.begin() = eval_type(e);
+      return partial_results.begin() + 1;
     }
   }
 
-  std::array<std::optional<eval_type>, num_internal_nodes<E>()> cache;
+  // Cache the rounded value and the index of the end of the non-zero element
+  // subspan
+  std::array<std::optional<std::pair<eval_type, std::size_t>>,
+             num_internal_nodes<E>()>
+      cache;
 
   allocator_type mem_pool;
 

--- a/src/ae_adaptive_predicate_eval.hpp
+++ b/src/ae_adaptive_predicate_eval.hpp
@@ -287,15 +287,12 @@ private:
                                   partial_results.begin() + reserve_left);
         }
       } else if constexpr (std::is_same_v<std::multiplies<>, Op>) {
-        const auto storage_mult =
-            partial_results.template last<partial_results.size() -
-                                          reserve_left - reserve_right>();
         if constexpr (_impl::linear_merge_lower_latency<eval_type,
                                                         sub_expr_>()) {
           _impl::sparse_mult_merge(storage_left, storage_right, partial_results,
                                    mem_pool);
         } else {
-          _impl::sparse_mult(storage_left, storage_right, storage_mult);
+          _impl::sparse_mult(storage_left, storage_right, partial_results);
         }
       }
     } else if constexpr (!std::is_same_v<additive_id, sub_expr>) {

--- a/src/ae_expr_utils.hpp
+++ b/src/ae_expr_utils.hpp
@@ -380,6 +380,42 @@ constexpr std::size_t get_memory_begin_idx() {
   }
 }
 
+// Useful functors for filtering and merging
+template <typename eval_type>
+static constexpr auto is_nonzero(const eval_type v) {
+  return v != eval_type{0};
+}
+
+template <typename eval_type, typename iterator>
+static constexpr auto zero_prune_store_inc(const eval_type v, iterator i)
+    -> iterator {
+  if constexpr (scalar_type<eval_type>) {
+    if (v) {
+      *i = v;
+      ++i;
+    }
+  } else {
+    *i = v;
+    ++i;
+  }
+  return i;
+}
+
+template <typename eval_type, typename iterator>
+static constexpr auto zero_prune_store_dec(const eval_type v, iterator i)
+    -> iterator {
+  if constexpr (scalar_type<eval_type>) {
+    if (v) {
+      *i = v;
+      --i;
+    }
+  } else {
+    *i = v;
+    --i;
+  }
+  return i;
+}
+
 // A simple (overly pessimistic) attempt to model latencies so decisions
 // regarding algorithm choices can be made by the compiler
 template <typename Op> consteval std::size_t op_latency() {

--- a/src/ae_expr_utils.hpp
+++ b/src/ae_expr_utils.hpp
@@ -404,7 +404,6 @@ auto copy_nonzero(range_type &range, allocator_type_ &&mem_pool) {
       std::distance(nonzero_range.begin(), nonzero_range.end());
   std::vector<eval_type, allocator_type> terms{size, mem_pool};
   std::ranges::copy(nonzero_range, terms.begin());
-  std::ranges::fill(range, eval_type{0});
   return terms;
 }
 

--- a/src/ae_expr_utils.hpp
+++ b/src/ae_expr_utils.hpp
@@ -386,6 +386,19 @@ static constexpr auto is_nonzero(const eval_type v) {
   return v != eval_type{0};
 }
 
+template <std::ranges::range range_type, typename allocator_type_>
+auto copy_nonzero(const range_type &range, allocator_type_ &&mem_pool) {
+  using eval_type = std::remove_cvref_t<decltype(*range.begin())>;
+  using allocator_type = std::remove_cvref_t<allocator_type_>;
+  auto nonzero_range = range | std::views::filter(is_nonzero<eval_type>);
+  const std::size_t size =
+      std::distance(nonzero_range.begin(), nonzero_range.end());
+  std::vector<eval_type, allocator_type> terms{size, mem_pool};
+  std::ranges::copy(nonzero_range, terms.begin());
+  std::ranges::fill(range, eval_type{0});
+  return terms;
+}
+
 template <typename eval_type, typename iterator>
 static constexpr auto zero_prune_store_inc(const eval_type v, iterator i)
     -> iterator {

--- a/src/ae_fp_eval.hpp
+++ b/src/ae_fp_eval.hpp
@@ -45,8 +45,7 @@ exactfp_eval(E &&e, allocator_type_ &&mem_pool =
     std::span<eval_type, storage_needed> partial_span{partial_results_ptr.get(),
                                                       storage_needed};
     _impl::exactfp_eval_impl<eval_type>(std::forward<E>(e), partial_span);
-    const eval_type result = _impl::merge_sum(partial_span);
-    return result;
+    return _impl::merge_sum(partial_span).first;
   } else {
     return static_cast<eval_type>(e);
   }

--- a/src/ae_fp_eval.hpp
+++ b/src/ae_fp_eval.hpp
@@ -44,8 +44,8 @@ exactfp_eval(E &&e, allocator_type_ &&mem_pool =
         mem_pool, storage_needed};
     std::span<eval_type, storage_needed> partial_span{partial_results_ptr.get(),
                                                       storage_needed};
-    _impl::exactfp_eval_impl<eval_type>(std::forward<E>(e), partial_span);
-    return _impl::merge_sum(partial_span).first;
+    auto last = _impl::exactfp_eval_impl<eval_type>(std::forward<E>(e), partial_span);
+    return _impl::merge_sum(std::span{partial_span.begin(), last}).first;
   } else {
     return static_cast<eval_type>(e);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 endif()
 
-add_executable(tests test_adaptive_expr.cpp test_geom_exprs.cpp test_determinant_4x4.cpp test_determinant_5x5.cpp)
+add_executable(tests test_adaptive_expr.cpp test_exact_eval.cpp test_geom_exprs.cpp test_determinant_4x4.cpp test_determinant_5x5.cpp)
 target_compile_features(tests PRIVATE cxx_std_23)
 target_compile_options(tests PRIVATE -fprofile-arcs -ftest-coverage)
 target_link_libraries(tests PRIVATE adaptive_predicates shewchuk Catch2::Catch2WithMain fmt)

--- a/tests/test_adaptive_expr.cpp
+++ b/tests/test_adaptive_expr.cpp
@@ -400,8 +400,15 @@ TEST_CASE("nonoverlapping", "[eval_utils]") {
   REQUIRE(midpoint1 > merge_test1.begin());
   REQUIRE(midpoint1 < merge_test1.end());
 
-  merge_sum_linear(merge_test1, midpoint1);
-  CHECK(is_nonoverlapping(merge_test1));
+  std::vector<real> left;
+  for (const auto v : std::span{merge_test1.begin(), merge_test1.begin() + 3}) {
+    left.push_back(v);
+  }
+  const auto merge_end =
+      merge_sum_linear(merge_test1, left,
+                       std::span{midpoint1, merge_test1.end() - 1})
+          .second;
+  CHECK(is_nonoverlapping(std::span{merge_test1.begin(), merge_end}));
 
   // Same strongly non-overlapping sequence but for merge_sum_linear_fast
   std::vector<real> merge_test2{0,

--- a/tests/test_adaptive_expr.cpp
+++ b/tests/test_adaptive_expr.cpp
@@ -342,7 +342,7 @@ TEST_CASE("expr_template_eval_simple", "[expr_template_eval]") {
   REQUIRE(exactfp_eval<real>(e.lhs()) == -15.0);
   REQUIRE(exactfp_eval<real>(e) == -14.5);
   std::vector<real> fp_vals{5.0, 10.0, 11.0, 11.0, 44.0};
-  REQUIRE(merge_sum(std::span{fp_vals}) == 81.0);
+  REQUIRE(merge_sum(std::span{fp_vals}).first == 81.0);
   REQUIRE(correct_eval<real>(e));
   REQUIRE(!correct_eval<real>(e + 14.5));
   REQUIRE(*correct_eval<real>(e.lhs().lhs().lhs().lhs()) == 0.0);
@@ -389,16 +389,12 @@ TEST_CASE("nonoverlapping", "[eval_utils]") {
   CHECK(
       !is_nonoverlapping(std::vector<real>{-0.375, 0.5, 1.5, 0, 0, 0, -14.0}));
 
-  std::vector<real> merge_test1{0,
-                                -1.5436178396078065e-49,
-                                -2.184158631330676e-33,
-                                -1.1470824290427116e-16,
-                                0,
-                                1.0353799381025734e-34,
-                                -1.7308376953906192e-17,
-                                -1.2053999999999998};
+  std::vector<real> merge_test1{
+      -1.5436178396078065e-49, -2.184158631330676e-33,
+      -1.1470824290427116e-16, 0,
+      1.0353799381025734e-34,  -1.7308376953906192e-17,
+      -1.2053999999999998,     0};
   const auto midpoint1 = merge_test1.begin() + 4;
-  CHECK(*midpoint1 == real{0});
   CHECK(is_nonoverlapping(std::span{merge_test1.begin(), midpoint1}));
   CHECK(is_nonoverlapping(std::span{midpoint1, merge_test1.end()}));
   REQUIRE(midpoint1 > merge_test1.begin());

--- a/tests/test_exact_eval.cpp
+++ b/tests/test_exact_eval.cpp
@@ -1,0 +1,194 @@
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <numeric>
+#include <ranges>
+
+#include "ae_expr.hpp"
+#include "ae_fp_eval.hpp"
+
+#include "testing_utils.hpp"
+
+using namespace adaptive_expr;
+using namespace _impl;
+
+using real = double;
+
+auto mult_test_case() {
+  const std::vector<real> left_terms{
+      9.2730153767185534643293381538690987834189119468944775061e-69,
+      -1.4836824602749685542926941046190558053470259115031164010e-67,
+      -8.0712325838958289353522559291276635810878209585769532213e-65,
+      -3.7146931176476335494342239740309342440743131677144559041e-50,
+      1.8816263559049057348829376728746432426858986035939542834e-48,
+      -2.2999754552016361580557916276085068746722863910872779169e-34,
+      -1.0014835710813626435891085301441622056398128570720018615e-32,
+      -5.7128445182814558007931378008513521845906262593833835339e-17,
+      8.8817841970012523233890533447265625000000000000000000000e-16,
+      2.6181623585046946089960329118184745311737060546875000000e+01};
+  const std::vector<real> right_terms{
+      3.4159996254284212719523204452351641690112422793523625658e-53,
+      -1.2829270608442539101474575042327113018312945024504233750e-49,
+      1.5826728910280977138562999662532483368295423737368913138e-33,
+      -5.3571703870932964415335228169487282410437732177140371381e-17};
+  std::vector<real> results(2 * left_terms.size() * right_terms.size());
+  return std::tuple{std::move(results), std::move(left_terms),
+                    std::move(right_terms)};
+}
+
+TEST_CASE("sparse_mult eval", "[sparse_mult]") {
+  auto [results, left, right] = mult_test_case();
+  std::vector<real> high_terms;
+  high_terms.reserve(left.size() * right.size());
+  std::vector<real> low_terms;
+  low_terms.reserve(left.size() * right.size());
+  for (const auto l : left) {
+    for (const auto r : right) {
+      const auto high = l * r;
+      high_terms.push_back(high);
+      const auto low = std::fma(l, r, -high);
+      low_terms.push_back(low);
+    }
+  }
+  std::span result_span{results};
+  const auto result_last =
+      sparse_mult(std::span{left}, std::span{right}, result_span);
+  for (const auto v : std::span{result_span.begin(), result_last}) {
+    // zero pruning check
+    CHECK(v != real{0});
+  }
+  // check that all of the expected values are in the result
+  for (const auto v : high_terms) {
+    if (v != real{0}) {
+      REQUIRE(std::find(result_span.begin(), result_last, v) != result_last);
+    }
+  }
+  for (const auto v : low_terms) {
+    if (v != real{0}) {
+      REQUIRE(std::find(result_span.begin(), result_last, v) != result_last);
+    }
+  }
+  for (const auto v : results) {
+    // Ensure that v is in either in_high or in_low, but not both
+    const bool in_high = std::ranges::find(high_terms, v) != high_terms.end();
+    const bool in_low = std::ranges::find(low_terms, v) != low_terms.end();
+    REQUIRE(in_high != in_low);
+  }
+}
+
+TEST_CASE("sparse_mult_merge eval", "[sparse_mult_merge]") {
+  auto [results, left, right] = mult_test_case();
+  REQUIRE(is_nonoverlapping(left));
+  REQUIRE(is_nonoverlapping(right));
+  std::vector expected_results = results;
+  sparse_mult(left, right, std::span{expected_results});
+  std::span result_span{results};
+  auto result_last =
+      sparse_mult_merge(left, right, result_span, std::allocator<real>());
+  REQUIRE(is_nonoverlapping(result_span));
+  std::vector<real> nonzero_results;
+  for (const auto v : std::span{result_span.begin(), result_last}) {
+    // zero-pruning check
+    REQUIRE(v != real{0});
+    nonzero_results.push_back(v);
+  }
+  // Check that the result is correct by subtracting values that sum to the same
+  // thing that a correct implementation produces
+  for (const auto v : expected_results) {
+    nonzero_results.push_back(-v);
+  }
+  result_span = std::span{nonzero_results};
+  const auto merge_result = merge_sum(result_span);
+  REQUIRE(merge_result.first == real{0});
+  REQUIRE(merge_result.second == result_span.begin());
+  for (const auto v : nonzero_results) {
+    REQUIRE(v == real{0});
+  }
+}
+
+auto mult_inplace_test_case() {
+  auto [results, left, right] = mult_test_case();
+  auto out = results.end();
+  for (const auto v : right) {
+    --out;
+    *out = v;
+  }
+  const auto right_begin = out;
+  for (const auto v : left) {
+    --out;
+    *out = v;
+  }
+  const auto left_begin = out;
+  return std::tuple{std::move(results), std::span{left_begin, right_begin},
+                    std::span{right_begin, results.end()}};
+}
+
+TEST_CASE("sparse_mult inplace eval", "[sparse_mult_inplace]") {
+  auto [results, left, right] = mult_inplace_test_case();
+  std::vector<real> high_terms;
+  high_terms.reserve(2 * left.size() * right.size());
+  std::vector<real> low_terms;
+  low_terms.reserve(left.size() * right.size());
+  for (const auto l : left) {
+    for (const auto r : right) {
+      const auto high = l * r;
+      high_terms.push_back(high);
+      const auto low = std::fma(l, r, -high);
+      low_terms.push_back(low);
+    }
+  }
+  std::span result_span{results};
+  const auto result_last =
+      sparse_mult(std::span{left}, std::span{right}, result_span);
+  for (const auto v : std::span{std::span{results}.begin(), result_last}) {
+    // zero pruning check
+    CHECK(v != real{0});
+  }
+  // check that all of the expected values are in the result
+  for (const auto v : high_terms) {
+    if (v != real{0}) {
+      REQUIRE(std::find(result_span.begin(), result_last, v) != result_last);
+    }
+  }
+  for (const auto v : low_terms) {
+    if (v != real{0}) {
+      REQUIRE(std::find(result_span.begin(), result_last, v) != result_last);
+    }
+  }
+  for (const auto v : results) {
+    // Ensure that v is in either in_high or in_low
+    const bool in_high = std::ranges::find(high_terms, v) != high_terms.end();
+    const bool in_low = std::ranges::find(low_terms, v) != low_terms.end();
+    REQUIRE(in_high != in_low);
+  }
+}
+
+TEST_CASE("sparse_mult_merge inplace eval", "[sparse_mult_merge_inplace]") {
+  auto [results, left, right] = mult_test_case();
+  REQUIRE(is_nonoverlapping(left));
+  REQUIRE(is_nonoverlapping(right));
+  std::vector expected_results = results;
+  sparse_mult(left, right, std::span{expected_results});
+  std::span result_span{results};
+  auto result_last =
+      sparse_mult_merge(left, right, result_span, std::allocator<real>());
+  REQUIRE(is_nonoverlapping(result_span));
+  std::vector<real> nonzero_results;
+  for (const auto v : std::span{result_span.begin(), result_last}) {
+    // zero pruning check
+    REQUIRE(v != real{0});
+    nonzero_results.push_back(v);
+  }
+  // Check that the result is correct by subtracting values that sum to the same
+  // thing that a correct implementation produces
+  for (const auto v : expected_results) {
+    nonzero_results.push_back(-v);
+  }
+  result_span = std::span{nonzero_results};
+  const auto merge_result = merge_sum(result_span);
+  REQUIRE(merge_result.first == real{0});
+  REQUIRE(merge_result.second == result_span.begin());
+  for (const auto v : nonzero_results) {
+    REQUIRE(v == real{0});
+  }
+}


### PR DESCRIPTION
Use the model to reduce adaptive evalution costs, deciding at compile time whether the linear merge sums + required lower level merge sums is better than just using the top level quadratic merge sum
Correct the estimated quadratic merge latency model to account for the quadratic merge assuming neither sums have been built as non-overlapping and non-adjacent
Add eval_type to the latency estimates, needed for two_sum which may has different characteristics for `vector_type` outputs